### PR TITLE
Rename spa.Module to spa.Network.

### DIFF
--- a/nengo_spa/__init__.py
+++ b/nengo_spa/__init__.py
@@ -4,7 +4,7 @@ from .basalganglia import BasalGanglia
 from .bind import Bind
 from .compare import Compare
 from .input import Input
-from .module import Module
+from .network import Network
 from .pointer import SemanticPointer
 from .product import Product
 from .scalar import Scalar

--- a/nengo_spa/actions.py
+++ b/nengo_spa/actions.py
@@ -217,27 +217,27 @@ class Actions(object):
 
         if len(Network.context) <= 0:
             raise NetworkContextError(
-                "Actions.build can only be called inside a ``with module:`` "
+                "Actions.build can only be called inside a ``with network:`` "
                 "block.")
-        root_module = Network.context[-1]
+        root_network = Network.context[-1]
 
-        with root_module:
+        with root_network:
             if needs_bg and bg is None:
                 bg = BasalGanglia(action_count=len(self.actions))
-                root_module.bg = bg
+                root_network.bg = bg
             if needs_bg and thalamus is None:
                 thalamus = Thalamus(action_count=len(self.actions))
                 for i, a in enumerate(self.actions):
                     thalamus.actions.ensembles[i].label = (
                         'action[{}]: {}'.format(i, a.effects))
                 thalamus.connect_bg(bg)
-                root_module.thalamus = thalamus
+                root_network.thalamus = thalamus
 
         self.construction_context = ConstructionContext(
-            root_module, bg=bg, thalamus=thalamus)
-        with root_module:
+            root_network, bg=bg, thalamus=thalamus)
+        with root_network:
             for action in self.actions:
-                action.infer_types(root_module, None)
+                action.infer_types(root_network, None)
             # Infer types for all actions before doing any construction, so
             # that # all semantic pointers are added to the respective
             # vocabularies so that the translate transform are identical.

--- a/nengo_spa/assoc_mem.py
+++ b/nengo_spa/assoc_mem.py
@@ -5,14 +5,14 @@ See :doc:`examples/associative_memory` for an introduction and examples.
 
 import nengo
 import numpy as np
-from nengo_spa.module import Module
+from nengo_spa.network import Network
 from nengo_spa.selection import IA, Thresholding, WTA
 from nengo_spa.vocab import VocabularyOrDimParam
 from nengo.utils.network import with_self
 
 
-class AssociativeMemory(Module):
-    """General associative memory module.
+class AssociativeMemory(Network):
+    """General associative memory network.
 
     This provides a low-level selection network with the necessary interface
     to include it within the SPA system.

--- a/nengo_spa/basalganglia.py
+++ b/nengo_spa/basalganglia.py
@@ -6,7 +6,7 @@ import nengo
 from nengo_spa.config import ConfigParam
 from nengo.networks.ensemblearray import EnsembleArray
 from nengo.params import Default, IntParam, NumberParam
-from nengo_spa.module import Module
+from nengo_spa.network import Network
 from nengo.synapses import Lowpass, SynapseParam
 
 
@@ -54,7 +54,7 @@ class Weights(object):
         return cls.mg * (x - cls.eg)
 
 
-class BasalGanglia(Module):
+class BasalGanglia(Network):
     """Winner take all network, typically used for action selection.
 
     The basal ganglia network outputs approximately 0 at the dimension with
@@ -106,7 +106,7 @@ class BasalGanglia(Module):
         and GPe to GPi and STN). If None, a default configuration using an
         8 ms lowpass synapse will be used.
     kwargs
-        Passed through the ``spa.Module``.
+        Passed through the ``spa.Network``.
 
     Attributes
     ----------

--- a/nengo_spa/bind.py
+++ b/nengo_spa/bind.py
@@ -1,12 +1,12 @@
 import nengo
 from nengo.params import BoolParam, Default, IntParam
 import nengo_spa
-from nengo_spa.module import Module
+from nengo_spa.network import Network
 from nengo_spa.vocab import VocabularyOrDimParam
 
 
-class Bind(Module):
-    """A module for binding together two inputs.
+class Bind(Network):
+    """A network for binding together two inputs.
 
     Binding is done with circular convolution. For more details on how
     this is computed, see the underlying `~.network.CircularConvolution`
@@ -25,7 +25,7 @@ class Bind(Module):
         Flipping the second input will make the network perform circular
         correlation instead of circular convolution.
     kwargs
-        Keyword arguments passed through to ``spa.Module``.
+        Keyword arguments passed through to ``spa.Network``.
     """
 
     vocab = VocabularyOrDimParam('vocab', default=None, readonly=True)

--- a/nengo_spa/compare.py
+++ b/nengo_spa/compare.py
@@ -2,12 +2,12 @@ import numpy as np
 
 import nengo
 from nengo.params import Default, IntParam
-from nengo_spa.module import Module
+from nengo_spa.network import Network
 from nengo_spa.vocab import VocabularyOrDimParam
 
 
-class Compare(Module):
-    """A module for computing the dot product of two inputs.
+class Compare(Network):
+    """A SPA network for computing the dot product of two inputs.
 
     Parameters
     ----------
@@ -17,7 +17,7 @@ class Compare(Module):
     neurons_per_dimension : int, optional (Default: 200)
         Number of neurons to use in each product computation.
     kwargs
-        Keyword arguments passed through to ``spa.Module``.
+        Keyword arguments passed through to ``spa.Network``.
     """
 
     vocab = VocabularyOrDimParam('vocab', default=None, readonly=True)

--- a/nengo_spa/exceptions.py
+++ b/nengo_spa/exceptions.py
@@ -2,8 +2,8 @@ class SpaException(Exception):
     """A exception within the SPA subsystem."""
 
 
-class SpaModuleError(SpaException, ValueError):
-    """An error in how SPA keeps track of modules."""
+class SpaNetworkError(SpaException, ValueError):
+    """An error in how SPA keeps track of networks."""
 
 
 class SpaParseError(SpaException, ValueError):

--- a/nengo_spa/input.py
+++ b/nengo_spa/input.py
@@ -48,8 +48,8 @@ class Input(nengo.Network):
 
     Parameters
     ----------
-    network : spa.Module, optional (Default: the current SPA network)
-        Module that this network provides input for.
+    network : spa.Network, optional (Default: the current SPA network)
+        Network that this instance provides input for.
     kwargs
         Keyword arguments passed through to ``nengo.Network``.
     """

--- a/nengo_spa/input.py
+++ b/nengo_spa/input.py
@@ -23,10 +23,10 @@ class _HierachicalInputProxy(object):
 
 
 class Input(nengo.Network):
-    """A SPA module for providing external inputs to other modules.
+    """A SPA network for providing external inputs to other networks.
 
-    The parameters passed to this module indicate the module input name
-    and the function to execute to generate inputs to that module.
+    The parameters passed to this network indicate the network input name
+    and the function to execute to generate inputs to that network.
     The functions should always return strings, which will then be parsed
     by the relevant vocabulary. For example::
 
@@ -40,33 +40,33 @@ class Input(nengo.Network):
 
     will create two inputs:
 
-    1. an input to the ``vision`` module, which for the first 0.1 seconds
+    1. an input to the ``vision`` network, which for the first 0.1 seconds
        is the value associated with the ``'A'`` semantic pointer and then
        a vector of all zeros, and
-    2. an input to the ``task`` module which is always the value associated
+    2. an input to the ``task`` network which is always the value associated
        with the ``'X'`` semantic pointer.
 
     Parameters
     ----------
-    module : spa.Module, optional (Default: the current module)
+    network : spa.Module, optional (Default: the current SPA network)
         Module that this network provides input for.
     kwargs
         Keyword arguments passed through to ``nengo.Network``.
     """
 
-    def __init__(self, module=None, **kwargs):
+    def __init__(self, network=None, **kwargs):
         super(Input, self).__init__(**kwargs)
         self.input_nodes = {}
 
-        if module is None:
-            from nengo_spa.module import get_current_module
-            module = get_current_module()
-        self.module = module
+        if network is None:
+            from nengo_spa.network import get_current_spa_network
+            network = get_current_spa_network()
+        self.network = network
 
         self._initialized = True
 
     def __connect(self, name, expr):
-        target, vocab = self.module.get_module_input(name)
+        target, vocab = self.network.get_network_input(name)
         if callable(expr):
             val = make_parse_func(expr, vocab)
         else:
@@ -76,7 +76,7 @@ class Input(nengo.Network):
             node = nengo.Node(val, label='input_%s' % name)
         self.input_nodes[name] = node
 
-        with self.module:
+        with self.network:
             nengo.Connection(node, target, synapse=None)
 
     def __setattr__(self, name, value):

--- a/nengo_spa/product.py
+++ b/nengo_spa/product.py
@@ -1,17 +1,17 @@
 import nengo
 from nengo.params import Default, IntParam
-from nengo_spa.module import Module
+from nengo_spa.network import Network
 
 
-class Product(Module):
-    """A module capable of multiplying two scalars.
+class Product(Network):
+    """A SPA network capable of multiplying two scalars.
 
     Parameters
     ----------
     n_neurons : int, optional (Default: 200)
         Number of neurons to use in product computation.
     kwargs
-        Keyword arguments passed through to ``spa.Module``.
+        Keyword arguments passed through to ``spa.Network``.
     """
 
     n_neurons = IntParam('n_neurons', default=200, low=1, readonly=True)

--- a/nengo_spa/scalar.py
+++ b/nengo_spa/scalar.py
@@ -1,10 +1,10 @@
 import nengo
 from nengo.params import Default, IntParam
-from nengo_spa.module import Module
+from nengo_spa.network import Network
 
 
-class Scalar(Module):
-    """A module capable of representing a single scalar.
+class Scalar(Network):
+    """A SPA network capable of representing a single scalar.
 
     Parameters
     ----------

--- a/nengo_spa/state.py
+++ b/nengo_spa/state.py
@@ -4,14 +4,15 @@ import nengo
 from nengo.exceptions import ValidationError
 from nengo.networks.ensemblearray import EnsembleArray
 from nengo.params import Default, IntParam, NumberParam
-from nengo_spa.module import Module
+from nengo_spa.network import Network
 from nengo_spa.vocab import VocabularyOrDimParam
 
 
-class State(Module):
-    """A module capable of representing a single vector, with optional memory.
+class State(Network):
+    """A SPA network capable of representing a single vector, with optional
+    memory.
 
-    This is a minimal SPA module, useful for passing data along (for example,
+    This is a minimal SPA network, useful for passing data along (for example,
     visual input).
 
     Parameters
@@ -31,7 +32,7 @@ class State(Module):
     feedback_synapse : float, optional (Default: 0.1)
         The synapse on the feedback connection.
     kwargs
-        Keyword arguments passed through to ``spa.Module``.
+        Keyword arguments passed through to ``spa.Network``.
     """
 
     vocab = VocabularyOrDimParam('vocab', default=None, readonly=True)

--- a/nengo_spa/tests/test_actions.py
+++ b/nengo_spa/tests/test_actions.py
@@ -7,7 +7,7 @@ from nengo_spa.exceptions import SpaTypeError
 
 
 def test_new_action_syntax(Simulator, seed, plt, rng):
-    model = spa.Module(seed=seed)
+    model = spa.Network(seed=seed)
     model.config[spa.State].vocab = 3
     model.config[spa.State].subdimensions = 3
     with model:
@@ -76,7 +76,7 @@ def test_new_action_syntax(Simulator, seed, plt, rng):
 def test_dot_product(Simulator, seed, plt):
     d = 16
 
-    with spa.Module(seed=seed) as model:
+    with spa.Network(seed=seed) as model:
         model.state_a = spa.State(d)
         model.state_b = spa.State(d)
         model.result = spa.Scalar()
@@ -103,7 +103,7 @@ def test_dot_product(Simulator, seed, plt):
 class TestExceptions():
     @pytest.fixture
     def model(self):
-        with spa.Module() as model:
+        with spa.Network() as model:
             model.state_a = spa.State(16)
             model.state_b = spa.State(32)
             model.state_c = spa.State(32)
@@ -174,7 +174,7 @@ def test_access_actions():
 
 
 def test_provides_access_to_constructed_objects_of_effect():
-    with spa.Module() as model:
+    with spa.Network() as model:
         model.config[spa.State].vocab = 16
         model.a = spa.State()
         model.b = spa.State()

--- a/nengo_spa/tests/test_assoc_mem.py
+++ b/nengo_spa/tests/test_assoc_mem.py
@@ -16,7 +16,7 @@ def test_am_basic(Simulator, plt, seed, rng):
     vocab = Vocabulary(d, rng=rng)
     vocab.populate('A; B; C; D')
 
-    with spa.Module('model', seed=seed) as m:
+    with spa.Network('model', seed=seed) as m:
         m.am = ThresholdingAssocMem(threshold=0.3, input_vocab=vocab,
                                     function=filtered_step_fn)
         m.stimulus = spa.Input()
@@ -56,7 +56,7 @@ def test_am_threshold(Simulator, plt, seed, rng):
     def input_func(t):
         return '0.49 * A' if t < 0.1 else '0.8 * B'
 
-    with spa.Module('model', seed=seed) as m:
+    with spa.Network('model', seed=seed) as m:
         m.am = ThresholdingAssocMem(
             threshold=0.5, input_vocab=vocab, output_vocab=vocab2,
             function=filtered_step_fn)
@@ -100,7 +100,7 @@ def test_am_wta(Simulator, plt, seed, rng):
         else:
             return '0.8 * A + B'
 
-    with spa.Module('model', seed=seed) as m:
+    with spa.Network('model', seed=seed) as m:
         m.am = WTAAssocMem(
             threshold=0.3, input_vocab=vocab, function=filtered_step_fn)
         m.stimulus = spa.Input()
@@ -139,7 +139,7 @@ def test_am_default_output(Simulator, plt, seed, rng):
     def input_func(t):
         return '0.2 * A' if t < 0.25 else 'A'
 
-    with spa.Module('model', seed=seed) as m:
+    with spa.Network('model', seed=seed) as m:
         m.am = ThresholdingAssocMem(threshold=0.5, input_vocab=vocab,
                                     function=filtered_step_fn)
         m.am.add_default_output('D', 0.5)
@@ -183,7 +183,7 @@ def test_am_spa_keys_as_expressions(Simulator, plt, seed, rng):
     in_keys = ['A', 'A*B']
     out_keys = ['C*D', 'C+D']
 
-    with spa.Module(seed=seed) as model:
+    with spa.Network(seed=seed) as model:
         model.am = ThresholdingAssocMem(
             threshold=0.3, input_vocab=vocab_in, output_vocab=vocab_out,
             input_keys=in_keys, output_keys=out_keys)

--- a/nengo_spa/tests/test_basalganglia.py
+++ b/nengo_spa/tests/test_basalganglia.py
@@ -5,7 +5,7 @@ import nengo_spa as spa
 
 
 def test_basal_ganglia(Simulator, seed, plt):
-    model = spa.Module(seed=seed)
+    model = spa.Network(seed=seed)
 
     with model:
         model.vision = spa.State(vocab=16)
@@ -70,14 +70,14 @@ def test_basal_ganglia(Simulator, seed, plt):
 
 
 def test_scalar_product():
-    with spa.Module() as model:
+    with spa.Network() as model:
         model.scalar = spa.Scalar()
         spa.Actions('scalar*scalar --> scalar=1').build()
     # just testing network construction without exception here
 
 
 def test_constructed_input_connections_are_accessible():
-    with spa.Module() as model:
+    with spa.Network() as model:
         model.config[spa.State].vocab = 16
         model.state1 = spa.State()
         model.state2 = spa.State()

--- a/nengo_spa/tests/test_bind.py
+++ b/nengo_spa/tests/test_bind.py
@@ -7,12 +7,12 @@ from nengo.utils.numpy import rmse
 
 
 def test_basic():
-    with spa.Module() as model:
+    with spa.Network() as model:
         model.bind = spa.Bind(vocab=16)
 
-    inputA = model.get_module_input('bind.input_a')
-    inputB = model.get_module_input('bind.input_b')
-    output = model.get_module_output('bind')
+    inputA = model.get_network_input('bind.input_a')
+    inputB = model.get_network_input('bind.input_b')
+    output = model.get_network_output('bind')
     # all nodes should be acquired correctly
     assert inputA[0] is model.bind.input_a
     assert inputB[0] is model.bind.input_b
@@ -28,7 +28,7 @@ def test_run(Simulator, seed):
     vocab = spa.Vocabulary(32, rng=rng)
     vocab.populate('A; B')
 
-    with spa.Module(seed=seed, vocabs=VocabularyMap([vocab])) as model:
+    with spa.Network(seed=seed, vocabs=VocabularyMap([vocab])) as model:
         model.bind = spa.Bind(vocab=32)
 
         def inputA(t):
@@ -41,7 +41,7 @@ def test_run(Simulator, seed):
         model.input.bind.input_a = inputA
         model.input.bind.input_b = 'A'
 
-    bind, vocab = model.get_module_output('bind')
+    bind, vocab = model.get_network_output('bind')
 
     with model:
         p = nengo.Probe(bind, 'output', synapse=0.03)

--- a/nengo_spa/tests/test_compare.py
+++ b/nengo_spa/tests/test_compare.py
@@ -3,12 +3,12 @@ import nengo_spa as spa
 
 
 def test_basic():
-    with spa.Module() as model:
+    with spa.Network() as model:
         model.compare = spa.Compare(vocab=16)
 
-    inputA = model.get_module_input('compare.input_a')
-    inputB = model.get_module_input('compare.input_b')
-    output = model.get_module_output('compare')
+    inputA = model.get_network_input('compare.input_a')
+    inputB = model.get_network_input('compare.input_b')
+    output = model.get_network_output('compare')
     # all nodes should be acquired correctly
     assert inputA[0] is model.compare.input_a
     assert inputB[0] is model.compare.input_b
@@ -21,7 +21,7 @@ def test_basic():
 
 
 def test_run(Simulator, seed):
-    with spa.Module(seed=seed) as model:
+    with spa.Network(seed=seed) as model:
         model.compare = spa.Compare(vocab=16)
         model.compare.vocab.populate('A; B')
 
@@ -35,7 +35,7 @@ def test_run(Simulator, seed):
         model.input.compare.input_a = inputA
         model.input.compare.input_b = 'A'
 
-    compare, vocab = model.get_module_output('compare')
+    compare, vocab = model.get_network_output('compare')
 
     with model:
         p = nengo.Probe(compare, 'output', synapse=0.03)

--- a/nengo_spa/tests/test_cortical.py
+++ b/nengo_spa/tests/test_cortical.py
@@ -3,11 +3,11 @@ import pytest
 
 import nengo
 import nengo_spa as spa
-from nengo_spa.exceptions import SpaModuleError
+from nengo_spa.exceptions import SpaNetworkError
 
 
 def test_connect(Simulator, seed):
-    with spa.Module(seed=seed) as model:
+    with spa.Network(seed=seed) as model:
         model.buffer1 = spa.State(vocab=16)
         model.buffer2 = spa.State(vocab=16)
         model.buffer3 = spa.State(vocab=16)
@@ -16,8 +16,8 @@ def test_connect(Simulator, seed):
         model.input = spa.Input()
         model.input.buffer1 = 'A'
 
-    output2, vocab = model.get_module_output('buffer2')
-    output3, vocab = model.get_module_output('buffer3')
+    output2, vocab = model.get_network_output('buffer2')
+    output3, vocab = model.get_network_output('buffer3')
 
     with model:
         p2 = nengo.Probe(output2, 'output', synapse=0.03)
@@ -33,14 +33,14 @@ def test_connect(Simulator, seed):
 
 
 def test_transform(Simulator, seed):
-    with spa.Module(seed=seed) as model:
+    with spa.Network(seed=seed) as model:
         model.buffer1 = spa.State(vocab=16)
         model.buffer2 = spa.State(vocab=16)
         spa.Actions('buffer2=buffer1*B').build()
         model.input = spa.Input()
         model.input.buffer1 = 'A'
 
-    output, vocab = model.get_module_output('buffer2')
+    output, vocab = model.get_network_output('buffer2')
 
     with model:
         p = nengo.Probe(output, 'output', synapse=0.03)
@@ -54,14 +54,14 @@ def test_transform(Simulator, seed):
 
 # FIXME test different populate arguments
 def test_translate(Simulator, seed):
-    with spa.Module(seed=seed) as model:
+    with spa.Network(seed=seed) as model:
         model.buffer1 = spa.State(vocab=16)
         model.buffer2 = spa.State(vocab=32)
         model.input = spa.Input()
         model.input.buffer1 = 'A'
         spa.Actions('buffer2=translate(buffer1, populate=True)').build()
 
-    output, vocab = model.get_module_output('buffer2')
+    output, vocab = model.get_network_output('buffer2')
 
     with model:
         p = nengo.Probe(output, 'output', synapse=0.03)
@@ -75,14 +75,14 @@ def test_translate(Simulator, seed):
 
 def test_errors():
     # buffer2 does not exist
-    with pytest.raises(SpaModuleError):
-        with spa.Module() as model:
+    with pytest.raises(SpaNetworkError):
+        with spa.Network() as model:
             model.buffer = spa.State(vocab=16)
             spa.Actions('buffer2=buffer').build()
 
 
 def test_direct(Simulator, seed):
-    with spa.Module(seed=seed) as model:
+    with spa.Network(seed=seed) as model:
         model.buffer1 = spa.State(vocab=16)
         model.buffer1.vocab.populate('A; B; C')
         model.buffer2 = spa.State(vocab=32)
@@ -90,8 +90,8 @@ def test_direct(Simulator, seed):
         spa.Actions(
             'buffer1=A', 'buffer2=B', 'buffer1=C, buffer2=C').build()
 
-    output1, vocab1 = model.get_module_output('buffer1')
-    output2, vocab2 = model.get_module_output('buffer2')
+    output1, vocab1 = model.get_network_output('buffer1')
+    output2, vocab2 = model.get_network_output('buffer2')
 
     with model:
         p1 = nengo.Probe(output1, 'output', synapse=0.03)
@@ -110,7 +110,7 @@ def test_direct(Simulator, seed):
 
 def test_convolution(Simulator, plt, seed):
     D = 5
-    with spa.Module(seed=seed) as model:
+    with spa.Network(seed=seed) as model:
         model.config[spa.State].vocab = D
         model.config[spa.State].subdimensions = D
         model.inA = spa.State()

--- a/nengo_spa/tests/test_input.py
+++ b/nengo_spa/tests/test_input.py
@@ -4,15 +4,15 @@ import nengo_spa as spa
 
 
 def test_fixed():
-    with spa.Module() as model:
+    with spa.Network() as model:
         model.buffer1 = spa.State(vocab=16)
         model.buffer2 = spa.State(vocab=8, subdimensions=8)
         model.input = spa.Input()
         model.input.buffer1 = 'A'
         model.input.buffer2 = 'B'
 
-    input1, vocab1 = model.get_module_input('buffer1')
-    input2, vocab2 = model.get_module_input('buffer2')
+    input1, vocab1 = model.get_network_input('buffer1')
+    input2, vocab2 = model.get_network_input('buffer2')
 
     assert np.allclose(model.input.input_nodes['buffer1'].output,
                        vocab1.parse('A').v)
@@ -21,7 +21,7 @@ def test_fixed():
 
 
 def test_time_varying():
-    with spa.Module() as model:
+    with spa.Network() as model:
         model.buffer = spa.State(vocab=16)
         model.buffer2 = spa.State(vocab=16)
 
@@ -37,7 +37,7 @@ def test_time_varying():
         model.input.buffer = input
         model.input.buffer2 = 'B'
 
-    input, vocab = model.get_module_input('buffer')
+    input, vocab = model.get_network_input('buffer')
 
     assert np.allclose(model.input.input_nodes['buffer'].output(t=0),
                        vocab.parse('A').v)
@@ -50,7 +50,7 @@ def test_time_varying():
 def test_predefined_vocabs():
     D = 64
 
-    with spa.Module() as model:
+    with spa.Network() as model:
         model.vocab1 = spa.Vocabulary(D)
         model.vocab1.populate('A; B; C')
 

--- a/nengo_spa/tests/test_spa_ast.py
+++ b/nengo_spa/tests/test_spa_ast.py
@@ -28,9 +28,9 @@ def test_symbol():
         ast.infer_types(None, TScalar)
 
 
-def test_module():
+def test_spa_network():
     d = 16
-    with spa.Module() as model:
+    with spa.Network() as model:
         model.state = spa.State(d)
 
     ast = Parser().parse_expr('state')
@@ -39,15 +39,15 @@ def test_module():
     ast.infer_types(model, None)
     assert ast.type.vocab == model.state.vocabs[d]
 
-    with spa.Module() as model:
-        with spa.Module() as model.module:
-            model.module.state = spa.State(d)
+    with spa.Network() as model:
+        with spa.Network() as model.network:
+            model.network.state = spa.State(d)
 
-    ast = Parser().parse_expr('module.state')
-    assert ast == Module('module.state')
-    assert str(ast) == 'module.state'
+    ast = Parser().parse_expr('network.state')
+    assert ast == Module('network.state')
+    assert str(ast) == 'network.state'
     ast.infer_types(model, None)
-    assert ast.type.vocab == model.module.state.vocabs[d]
+    assert ast.type.vocab == model.network.state.vocabs[d]
 
 
 def test_scalar_multiplication():
@@ -68,7 +68,7 @@ def test_scalar_multiplication():
     assert ast.type == vocab_type
 
     d = 16
-    with spa.Module() as model:
+    with spa.Network() as model:
         model.state = spa.State(d)
 
     ast = Parser().parse_expr('2 * state')
@@ -97,7 +97,7 @@ def test_binary_operations(symbol, klass):
     assert ast.type == vocab_type
 
     d = 16
-    with spa.Module() as model:
+    with spa.Network() as model:
         model.state = spa.State(d)
         model.state2 = spa.State(d)
 
@@ -135,7 +135,7 @@ def test_unary(symbol, klass):
     assert ast.type == vocab_type
 
     d = 16
-    with spa.Module() as model:
+    with spa.Network() as model:
         model.state = spa.State(d)
 
     ast = Parser().parse_expr(symbol + 'state')
@@ -148,7 +148,7 @@ def test_unary(symbol, klass):
 
 def test_dot_product():
     d = 16
-    with spa.Module() as model:
+    with spa.Network() as model:
         model.state = spa.State(d)
 
     ast = Parser().parse_expr('dot(A, state)')
@@ -168,7 +168,7 @@ def test_dot_product():
 
 def test_effect():
     d = 16
-    with spa.Module() as model:
+    with spa.Network() as model:
         model.state = spa.State(d)
 
     ast = Parser().parse_effect('state = A')
@@ -196,7 +196,7 @@ def test_effects():
 
 def test_action():
     d = 16
-    with spa.Module() as model:
+    with spa.Network() as model:
         model.state = spa.State(d)
 
     ast = Parser().parse_action('dot(state, A) --> state = B')
@@ -209,7 +209,7 @@ def test_action():
 
 def test_complex_epressions():
     d = 16
-    with spa.Module() as model:
+    with spa.Network() as model:
         model.state = spa.State(d)
 
     ast = Parser().parse_expr('~(A - B * state)')
@@ -235,7 +235,7 @@ def test_complex_epressions():
 
 def test_zero_vector():
     d = 16
-    with spa.Module() as model:
+    with spa.Network() as model:
         model.state = spa.State(d)
 
     ast = Parser().parse_effect('state = 0')
@@ -245,7 +245,7 @@ def test_zero_vector():
 
 def test_vocab_transform_in_multiplication():
     d = 16
-    with spa.Module() as model:
+    with spa.Network() as model:
         model.state = spa.State(d)
 
     ast = Parser().parse_expr('2 * translate(state)')

--- a/nengo_spa/tests/test_state.py
+++ b/nengo_spa/tests/test_state.py
@@ -5,11 +5,11 @@ import nengo_spa as spa
 
 
 def test_basic():
-    with spa.Module() as model:
+    with spa.Network() as model:
         model.state = spa.State(vocab=16)
 
-    input = model.get_module_input('state')
-    output = model.get_module_output('state')
+    input = model.get_network_input('state')
+    output = model.get_network_output('state')
     assert input[0] is model.state.input
     assert output[0] is model.state.output
     assert input[1] is output[1]
@@ -17,13 +17,13 @@ def test_basic():
 
 
 def test_neurons():
-    with spa.Module() as model:
+    with spa.Network() as model:
         model.state = spa.State(vocab=16, neurons_per_dimension=2)
 
     assert len(model.state.state_ensembles.ensembles) == 1
     assert model.state.state_ensembles.ensembles[0].n_neurons == 16 * 2
 
-    with spa.Module() as model:
+    with spa.Network() as model:
         model.state = spa.State(vocab=16, subdimensions=1,
                                 neurons_per_dimension=2)
 
@@ -32,7 +32,7 @@ def test_neurons():
 
 
 def test_no_feedback_run(Simulator, seed):
-    with spa.Module(seed=seed) as model:
+    with spa.Network(seed=seed) as model:
         model.state = spa.State(vocab=32, feedback=0.0)
 
         def state_input(t):
@@ -45,7 +45,7 @@ def test_no_feedback_run(Simulator, seed):
         model.state_input = spa.Input()
         model.state_input.state = state_input
 
-    state, vocab = model.get_module_output('state')
+    state, vocab = model.get_network_output('state')
 
     with model:
         p = nengo.Probe(state, 'output', synapse=0.03)
@@ -63,7 +63,7 @@ def test_no_feedback_run(Simulator, seed):
 
 
 def test_memory_run(Simulator, seed, plt):
-    with spa.Module(seed=seed) as model:
+    with spa.Network(seed=seed) as model:
         model.memory = spa.State(vocab=32, feedback=1.0,
                                  feedback_synapse=0.01)
 
@@ -76,7 +76,7 @@ def test_memory_run(Simulator, seed, plt):
         model.state_input = spa.Input()
         model.state_input.memory = state_input
 
-    memory, vocab = model.get_module_output('memory')
+    memory, vocab = model.get_network_output('memory')
 
     with model:
         p = nengo.Probe(memory, 'output', synapse=0.03)
@@ -97,7 +97,7 @@ def test_memory_run(Simulator, seed, plt):
 
 
 def test_memory_run_decay(Simulator, plt, seed):
-    with spa.Module(seed=seed) as model:
+    with spa.Network(seed=seed) as model:
         model.memory = spa.State(vocab=32, feedback=(1.0 - 0.01/0.05),
                                  feedback_synapse=0.01)
 
@@ -110,7 +110,7 @@ def test_memory_run_decay(Simulator, plt, seed):
         model.state_input = spa.Input()
         model.state_input.memory = state_input
 
-    memory, vocab = model.get_module_output('memory')
+    memory, vocab = model.get_network_output('memory')
 
     with model:
         p = nengo.Probe(memory, 'output', synapse=0.03)

--- a/nengo_spa/tests/test_thalamus.py
+++ b/nengo_spa/tests/test_thalamus.py
@@ -2,14 +2,14 @@ import pytest
 
 import nengo
 import nengo_spa as spa
-from nengo_spa.exceptions import SpaModuleError
+from nengo_spa.exceptions import SpaNetworkError
 
 import numpy as np
 
 
 @pytest.mark.slow
 def test_thalamus(Simulator, plt, seed):
-    model = spa.Module(seed=seed)
+    model = spa.Network(seed=seed)
 
     with model:
         model.vision = spa.State(vocab=16, neurons_per_dimension=80)
@@ -37,8 +37,8 @@ def test_thalamus(Simulator, plt, seed):
         model.input.vision = input_f
         model.input.vision2 = 'B*~A'
 
-        input, vocab = model.get_module_input('motor')
-        input2, vocab2 = model.get_module_input('motor2')
+        input, vocab = model.get_network_input('motor')
+        input2, vocab2 = model.get_network_input('motor2')
         p = nengo.Probe(input, 'output', synapse=0.03)
         p2 = nengo.Probe(input2, 'output', synapse=0.03)
 
@@ -72,7 +72,7 @@ def test_thalamus(Simulator, plt, seed):
 
 
 def test_routing(Simulator, seed, plt):
-    model = spa.Module(seed=seed)
+    model = spa.Network(seed=seed)
     model.config[spa.State].vocab = 3
     model.config[spa.State].subdimensions = 3
     with model:
@@ -131,7 +131,7 @@ def test_routing(Simulator, seed, plt):
 
 
 def test_routing_recurrency_compilation(Simulator, seed, plt):
-    model = spa.Module(seed=seed)
+    model = spa.Network(seed=seed)
     model.config[spa.State].vocab = 2
     model.config[spa.State].subdimensions = 2
     with model:
@@ -144,7 +144,7 @@ def test_routing_recurrency_compilation(Simulator, seed, plt):
 
 
 def test_nondefault_routing(Simulator, seed):
-    model = spa.Module(seed=seed)
+    model = spa.Network(seed=seed)
     model.config[spa.State].vocab = 3
     model.config[spa.State].subdimensions = 3
     with model:
@@ -194,14 +194,14 @@ def test_nondefault_routing(Simulator, seed):
 
 def test_errors():
     # motor does not exist
-    with pytest.raises(SpaModuleError):
-        with spa.Module() as model:
+    with pytest.raises(SpaNetworkError):
+        with spa.Network() as model:
             model.vision = spa.State(vocab=16)
             spa.Actions('0.5 --> motor=A').build()
 
 
 def test_constructed_objects_are_accessible():
-    with spa.Module() as model:
+    with spa.Network() as model:
         model.config[spa.State].vocab = 16
         model.state1 = spa.State()
         model.state2 = spa.State()

--- a/nengo_spa/thalamus.py
+++ b/nengo_spa/thalamus.py
@@ -3,13 +3,13 @@ import numpy as np
 import nengo
 from nengo.dists import Uniform
 from nengo.params import Default, IntParam, NumberParam
-from nengo_spa.module import Module
+from nengo_spa.network import Network
 from nengo_spa.scalar import Scalar
 from nengo_spa.state import State
 from nengo.synapses import Lowpass, SynapseParam
 
 
-class Thalamus(Module):
+class Thalamus(Network):
     """Inhibits non-selected actions.
 
     The thalamus is intended to work in tandem with a basal ganglia network.
@@ -50,7 +50,7 @@ class Thalamus(Module):
         Synaptic filter for controlling a gate.
 
     kwargs
-        Passed through to ``spa.Module``.
+        Passed through to ``spa.Network``.
 
     Attributes
     ----------
@@ -100,7 +100,7 @@ class Thalamus(Module):
         self.synapse_bg = synapse_bg
 
         self.gates = {}     # gating ensembles per action (created as needed)
-        self.channels = []  # channels to pass transformed data between modules
+        self.channels = []  # channels to pass data between networks
 
         self.gate_in_connections = {}
         self.gate_out_connections = {}
@@ -164,7 +164,7 @@ class Thalamus(Module):
         return self.gates[index]
 
     def construct_channel(
-            self, target_module, target_input, net, label=None):
+            self, target_net, target_input, net, label=None):
         """Construct a channel.
 
         Channels are an additional neural population in-between a source
@@ -173,8 +173,8 @@ class Thalamus(Module):
 
         Parameters
         ----------
-        target_module : :class:`spa.Module`
-            The module that the channel will project to.
+        target_net : :class:`spa.Network`
+            The network that the channel will project to.
         target_vocab : :class:`spa.Vocabulary`
             The vocabulary used by the target population..
         net : :class:`nengo.Network`, optional
@@ -188,8 +188,8 @@ class Thalamus(Module):
             The constructed channel.
         """
         if label is None:
-            if target_module.label is not None:
-                label = 'channel to ' + target_module.label
+            if target_net.label is not None:
+                label = 'channel to ' + target_net.label
             else:
                 label = 'channel'
         with net:

--- a/nengo_spa/utils.py
+++ b/nengo_spa/utils.py
@@ -1,4 +1,4 @@
-"""These are helper functions to simplify some operations in the SPA module."""
+"""These are helper functions to simplify some operations in the SPA."""
 from itertools import combinations
 
 import numpy as np


### PR DESCRIPTION
**Motivation and context:**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it addresses an open issue, please link to the issue here. -->

Addresses nengo/nengo#1133.

There is no distinction between `spa.SPA` and `spa.Module` anymore. Furthermore, `spa.Module` can be used like any other `nengo.Network`. Thus, this renames `spa.Module` to `spa.Network`. If you intend to use SPA functionality, you can just switch to use `spa.Network` instead of `nengo.Network` everywhere.

**Interactions with other PRs:**
<!--- If this change depends on or conflicts with another PR please list it here. -->
<!--- If this PR contains commits from another PR, describe what commits in this PR are unique. -->
<!--- If this PR is independent, then remove this section. -->
none

**How has this been tested?**
<!--- Please describe in detail how you tested your changes. -->
<!--- Reviewers will test your PR in at least this way. -->
unit tests still pass

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Where should a reviewer start?**
<!--- If the PR warrants it, indicate where a reviewer should start reviewing. -->
<!--- All lengthy PRs and complicated average PRs warrant this section. -->
<!--- If the PR is quick or straightforward, remove this section. -->
It's just the renaming and adjusting doc strings accordingly. Hopefully, quick to review even though many lines have been touched.


**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [x] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Still to do:**
<!--- If this is a work in progress, note below what you stil plan to do. -->
<!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->

- [x] Check that no lines got longer than 80 characters.