### PR TITLE
Improve error messages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,13 @@ Release History
   (`#30 <https://github.com/nengo/nengo/pull/30>`_,
   `#23 <https://github.com/nengo/nengo/issues/23>`_)
 
+**Fixed**
+
+- Improved a number of error messages.
+  (`#35 <https://github.com/nengo/nengo/pull/35>`_,
+  `#32 <https://github.com/nengo/nengo/issues/32>`_,
+  `#34 <https://github.com/nengo/nengo/issues/34>`_)
+
 
 0.1.1 (May 19, 2017)
 ====================

--- a/nengo_spa/ast.py
+++ b/nengo_spa/ast.py
@@ -87,7 +87,7 @@ from nengo_spa.modules.bind import Bind
 from nengo_spa.modules.compare import Compare
 from nengo_spa.pointer import SemanticPointer
 from nengo_spa.modules.product import Product as ProductModule
-from nengo_spa.exceptions import SpaNetworkError, SpaParseError, SpaTypeError
+from nengo_spa.exceptions import SpaConstructionError, SpaParseError, SpaTypeError
 
 
 class ConstructionContext(object):
@@ -1047,7 +1047,7 @@ class Action(Node):
 
     def construct(self, context):
         if context.bg is None or context.thalamus is None:
-            raise SpaNetworkError(
+            raise SpaConstructionError(
                 "Conditional actions require basal ganglia and thalamus.")
 
         # construct bg utility

--- a/nengo_spa/exceptions.py
+++ b/nengo_spa/exceptions.py
@@ -2,8 +2,36 @@ class SpaException(Exception):
     """A exception within the SPA subsystem."""
 
 
-class SpaNetworkError(SpaException, ValueError):
-    """An error in how SPA keeps track of networks."""
+class SpaConstructionError(SpaException):
+    """An error in the construction of SPA action rules."""
+
+
+class SpaNameError(SpaException, ValueError):
+    """An error in finding a network, input, or output.
+
+    Parameters
+    ----------
+    name : str
+        Name that could not be found.
+    kind : str
+        Type of the name not being found (e.g. 'network', 'network input', ...)
+
+    Attributes
+    ----------
+    name : str
+        Name that could not be found.
+    kind : str
+        Type of the name not being found (e.g. 'network', 'network input', ...)
+    """
+
+    def __init__(self, name, kind):
+        super(SpaNameError, self).__init__()
+        self.name = name
+        self.kind = kind
+
+    def __str__(self):
+        return "Could not find {kind} {name!r}.".format(
+            kind=self.kind, name=self.name)
 
 
 class SpaParseError(SpaException, ValueError):

--- a/nengo_spa/modules/tests/test_cortical.py
+++ b/nengo_spa/modules/tests/test_cortical.py
@@ -3,7 +3,7 @@ import pytest
 
 import nengo
 import nengo_spa as spa
-from nengo_spa.exceptions import SpaNetworkError
+from nengo_spa.exceptions import SpaNameError
 
 
 def test_connect(Simulator, seed):
@@ -75,10 +75,12 @@ def test_translate(Simulator, seed):
 
 def test_errors():
     # buffer2 does not exist
-    with pytest.raises(SpaNetworkError):
+    with pytest.raises(SpaNameError) as excinfo:
         with spa.Network() as model:
             model.buffer = spa.State(vocab=16)
             spa.Actions('buffer2=buffer').build()
+
+    assert excinfo.value.name == 'buffer2'
 
 
 def test_direct(Simulator, seed):

--- a/nengo_spa/modules/tests/test_thalamus.py
+++ b/nengo_spa/modules/tests/test_thalamus.py
@@ -2,7 +2,7 @@ import pytest
 
 import nengo
 import nengo_spa as spa
-from nengo_spa.exceptions import SpaNetworkError
+from nengo_spa.exceptions import SpaNameError
 
 import numpy as np
 
@@ -218,10 +218,12 @@ def test_nondefault_routing(Simulator, seed):
 
 def test_errors():
     # motor does not exist
-    with pytest.raises(SpaNetworkError):
+    with pytest.raises(SpaNameError) as excinfo:
         with spa.Network() as model:
             model.vision = spa.State(vocab=16)
             spa.Actions('0.5 --> motor=A').build()
+
+    assert excinfo.value.name == 'motor'
 
 
 def test_constructed_objects_are_accessible():

--- a/nengo_spa/network.py
+++ b/nengo_spa/network.py
@@ -2,7 +2,7 @@ import numpy as np
 
 import nengo
 from nengo.config import Config, SupportDefaultsMixin
-from nengo_spa.exceptions import SpaConstructionError, SpaNameError
+from nengo_spa.exceptions import SpaNameError
 from nengo_spa.modules.input import Input
 from nengo_spa.vocab import VocabularyMap, VocabularyMapParam
 
@@ -83,11 +83,6 @@ class Network(nengo.Network, SupportDefaultsMixin):
             return super(Network, self).__setattr__(key, value)
 
         if isinstance(value, Network):
-            if hasattr(self, key) and isinstance(getattr(self, key), Network):
-                raise SpaConstructionError(
-                    "Cannot re-assign network-attribute %s to %s. SPA "
-                    "network-attributes can only be assigned once."
-                    % (key, value))
             if value.label is None:
                 value.label = key
 

--- a/nengo_spa/network.py
+++ b/nengo_spa/network.py
@@ -54,8 +54,6 @@ class Network(nengo.Network, SupportDefaultsMixin):
 
         self._stimuli = None
 
-        self._initialized = True
-
     @property
     def config(self):
         return _AutoConfig(self._config)
@@ -66,27 +64,6 @@ class Network(nengo.Network, SupportDefaultsMixin):
         if self._stimuli is None:
             self._stimuli = Input(self)
         return self._stimuli
-
-    def __setstate__(self, state):
-        if '_initialized' in state:
-            del state['_initialized']
-        super(Network, self).__setstate__(state)
-        setattr(self, '_initialized', True)
-
-    def __setattr__(self, key, value):
-        """A setattr that handles SPA networks being added specially.
-
-        This is so that we can use the variable name for the Network as
-        the name that all of the SPA system will use to access that network.
-        """
-        if not hasattr(self, '_initialized'):
-            return super(Network, self).__setattr__(key, value)
-
-        if isinstance(value, Network):
-            if value.label is None:
-                value.label = key
-
-        super(Network, self).__setattr__(key, value)
 
     def get_spa_network(self, name, strip_output=False):
         """Return the SPA network for the given name.

--- a/nengo_spa/tests/test_network.py
+++ b/nengo_spa/tests/test_network.py
@@ -3,7 +3,8 @@ import pytest
 
 import nengo
 import nengo_spa as spa
-from nengo_spa.exceptions import SpaNetworkError, SpaTypeError
+from nengo_spa.exceptions import (
+    SpaConstructionError, SpaNameError, SpaTypeError)
 from nengo_spa.examine import similarity
 from nengo_spa.vocab import VocabularyMap
 
@@ -46,7 +47,7 @@ def test_spa_verification(seed, plt):
         model.int_val = 2
 
     # reassignment of networks should throw an error
-    with pytest.raises(ValueError):
+    with pytest.raises(SpaConstructionError):
         with model:
             model.buf = spa.State(d, feedback=1)
 
@@ -74,8 +75,9 @@ def test_spa_get():
         model.compare = spa.Compare(D)
 
     assert model.get_spa_network('buf1') is model.buf1
-    with pytest.raises(SpaNetworkError):
+    with pytest.raises(SpaNameError) as excinfo:
         model.get_spa_network('buf1.default')
+    assert excinfo.value.name == 'buf1.default'
     assert model.get_spa_network('buf2') is model.buf2
     assert model.get_network_input('buf1')[0] is model.buf1.input
     assert model.get_network_input('buf1.default')[0] is model.buf1.input
@@ -86,16 +88,30 @@ def test_spa_get():
     assert model.get_network_input(
         'compare.input_b')[0] is model.compare.input_b
 
-    with pytest.raises(SpaNetworkError):
+    with pytest.raises(SpaNameError) as excinfo:
         model.get_spa_network('dummy')
-    with pytest.raises(SpaNetworkError):
+    assert excinfo.value.name == 'dummy'
+    assert excinfo.value.kind == 'network'
+
+    with pytest.raises(SpaNameError) as excinfo:
         model.get_network_input('dummy')
-    with pytest.raises(SpaNetworkError):
+    assert excinfo.value.name == 'dummy'
+    assert excinfo.value.kind == 'network input'
+
+    with pytest.raises(SpaNameError) as excinfo:
         model.get_network_output('dummy')
-    with pytest.raises(SpaNetworkError):
+    assert excinfo.value.name == 'dummy'
+    assert excinfo.value.kind == 'network output'
+
+    with pytest.raises(SpaNameError) as excinfo:
         model.get_network_input('buf1.A')
-    with pytest.raises(SpaNetworkError):
+    assert excinfo.value.name == 'buf1.A'
+    assert excinfo.value.kind == 'network input'
+
+    with pytest.raises(SpaNameError) as excinfo:
         model.get_network_input('compare')
+    assert excinfo.value.name == 'compare.default'
+    assert excinfo.value.kind == 'network input'
 
 
 def test_spa_vocab():

--- a/nengo_spa/tests/test_network.py
+++ b/nengo_spa/tests/test_network.py
@@ -110,7 +110,7 @@ def test_spa_get():
 
     with pytest.raises(SpaNameError) as excinfo:
         model.get_network_input('compare')
-    assert excinfo.value.name == 'compare.default'
+    assert excinfo.value.name == 'compare'
     assert excinfo.value.kind == 'network input'
 
 

--- a/nengo_spa/tests/test_network.py
+++ b/nengo_spa/tests/test_network.py
@@ -3,8 +3,7 @@ import pytest
 
 import nengo
 import nengo_spa as spa
-from nengo_spa.exceptions import (
-    SpaConstructionError, SpaNameError, SpaTypeError)
+from nengo_spa.exceptions import SpaNameError, SpaTypeError
 from nengo_spa.examine import similarity
 from nengo_spa.vocab import VocabularyMap
 
@@ -45,11 +44,6 @@ def test_spa_verification(seed, plt):
 
         # reassignment is fine for non-networks
         model.int_val = 2
-
-    # reassignment of networks should throw an error
-    with pytest.raises(SpaConstructionError):
-        with model:
-            model.buf = spa.State(d, feedback=1)
 
 
 def test_spa_network_exception():

--- a/nengo_spa/vocab.py
+++ b/nengo_spa/vocab.py
@@ -125,8 +125,9 @@ class Vocabulary(Mapping):
         """
         if not valid_sp_regex.match(key):
             raise SpaParseError(
-                "Invalid Semantic Pointer name. Valid names are valid "
-                "Python 2 identifiers beginning with a capital letter.")
+                "Invalid Semantic Pointer name {!r}. Valid names are valid "
+                "Python 2 identifiers beginning with a capital letter.".format(
+                    key))
         if not isinstance(p, pointer.SemanticPointer):
             p = pointer.SemanticPointer(p)
 

--- a/nengo_spa/vocab.py
+++ b/nengo_spa/vocab.py
@@ -171,9 +171,10 @@ class Vocabulary(Mapping):
         # pointers as needed.
         try:
             value = eval(text, {}, self)
-        except NameError:
+        except NameError as err:
             raise SpaParseError(
-                "Semantic pointers must start with a capital letter.")
+                "Error parsing expression {expr!r} with {vocab}: {msg}".format(
+                    expr=text, vocab=self, msg=str(err)))
 
         if is_number(value):
             value *= Identity(self.dimensions)


### PR DESCRIPTION
**Motivation and context:**
This PR improves some error messages to fix #32 and #34. As this touches `spa.Network.get_network_input` and `spa.Network.get_network_output`, I used this to also refactor these functions to reduce code duplication and make the implementation slightly simpler.

There is one exception, when a `spa.Network` attribute gets reassigned, that I completely removed because it seems to be unnecessary. I think the reassignment was only a problem in the legacy SPA, but I'm not entirely sure for the initial reason to introduce this exception. Tagging @Seanny123 and @tcstewar who might remember more details. Also, see description of commit d82bab8940fcbdc8ac9de3796171710ccc29886c.

In #29, @ikajic noted that an associative memory gives a misleading exception when the output vocabulary is missing keys. The general parse error given by vocabularies has been fixed in this PR, but currently the associative memory does not add any further detail to it. For example, for code like this
```python
spa.ThresholdingAssocMem(threshold=0.2, input_vocab=v1, output_vocab=v2, mapping='by-key')
```
the following exception might be produced:
```
SpaParseError: Error parsing expression 'A' with 32-dimensional vocab at 0x7f954d053f28: name 'A' is not defined
```
This is definitely an improvement, but is it good enough? If not how can this error message be made more helpful?

**Interactions with other PRs:**
none

**How has this been tested?**
Unit tests still pass. Tested the parsing exception for `Vocabulary` manually because it is a bit of a hassle to verify the message string in a unit test.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Where should a reviewer start?**
I'd recommend doing this on a commit by commit basis.

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] All new and existing tests passed.