### PR TITLE
Fix spaopt

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,9 @@ Release History
   (`#35 <https://github.com/nengo/nengo/pull/35>`_,
   `#32 <https://github.com/nengo/nengo/issues/32>`_,
   `#34 <https://github.com/nengo/nengo/issues/34>`_)
+- Improved accuracy by fixing choice of evaluation point and intercept
+  distributions.
+  (`#39 <https://github.com/nengo/nengo_spa/pull/39>`_)
 
 
 0.1.1 (May 19, 2017)

--- a/nengo_spa/modules/tests/test_cortical.py
+++ b/nengo_spa/modules/tests/test_cortical.py
@@ -136,6 +136,16 @@ def test_convolution(Simulator, plt, seed):
         pAinvB = nengo.Probe(model.outAinvB.output, synapse=0.03)
         pAinvBinv = nengo.Probe(model.outAinvBinv.output, synapse=0.03)
 
+    for state in [
+            model.inA,
+            model.inB,
+            model.outAB,
+            model.outABinv,
+            model.outAinvB,
+            model.outAinvBinv]:
+        for e in state.all_ensembles:
+            e.radius = 1.
+
     with Simulator(model) as sim:
         sim.run(0.2)
 
@@ -169,16 +179,16 @@ def test_convolution(Simulator, plt, seed):
 
     # Ideal answer: A*B = [0,0,0,1,0]
     assert np.allclose(np.mean(sim.data[pAB][-10:], axis=0),
-                       np.array([0, 0, 0, 1, 0]), atol=0.2)
+                       np.array([0, 0, 0, 1, 0]), atol=0.25)
 
     # Ideal answer: A*~B = [0,0,0,0,1]
     assert np.allclose(np.mean(sim.data[pABinv][-10:], axis=0),
-                       np.array([0, 0, 0, 0, 1]), atol=0.2)
+                       np.array([0, 0, 0, 0, 1]), atol=0.25)
 
     # Ideal answer: ~A*B = [0,1,0,0,0]
     assert np.allclose(np.mean(sim.data[pAinvB][-10:], axis=0),
-                       np.array([0, 1, 0, 0, 0]), atol=0.2)
+                       np.array([0, 1, 0, 0, 0]), atol=0.25)
 
     # Ideal answer: ~A*~B = [0,0,1,0,0]
     assert np.allclose(np.mean(sim.data[pAinvBinv][-10:], axis=0),
-                       np.array([0, 0, 1, 0, 0]), atol=0.2)
+                       np.array([0, 0, 1, 0, 0]), atol=0.25)


### PR DESCRIPTION
**Motivation and context:**
Benchmarking is hard and I screwed up. The circular convolution wasn't nearly as accurate as it was supposed to be because I only validated the choice of distributions on 50 neurons per dimensions. The choice proposed in this PR is validated on 50 and 200 neurons per dimensions and also for convolution of random + unitary vector, random + random vector, unitary + unitary vector.

[I updated the corresponding section in the intercept distribution notebook.](https://github.com/ctn-waterloo/internal_tech_reports/blob/master/The%20influence%20of%20the%20intercept%20distribution%20on%20representation%20in%20the%20NEF.ipynb)

@rworr, this might be relevant to you.

**Interactions with other PRs:**
none

**How has this been tested?**
Validation done elsewhere, the linked notebook gives the main conclusions.
Unit tests still pass, though one test needed adjustment because it violated the assumption of high-dimensional random vectors.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] All new and existing tests passed.