### PR TITLE
Fix transforms on first vector in vocab.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,9 @@ Release History
 - Improved accuracy by fixing choice of evaluation point and intercept
   distributions.
   (`#39 <https://github.com/nengo/nengo_spa/pull/39>`_)
+- Correctly apply transforms on first vector in vocabularies on on non-strict
+  vocabularies.
+  (`#43 <https://github.com/nengo/nengo_spa/pull/43>)
 
 
 0.1.1 (May 19, 2017)

--- a/nengo_spa/tests/test_vocabulary.py
+++ b/nengo_spa/tests/test_vocabulary.py
@@ -63,6 +63,14 @@ def test_populate(rng):
     v.populate(u'Aα = A')
 
 
+def test_populate_with_transform_on_first_vector(rng):
+    v = Vocabulary(64, rng=rng)
+
+    v.populate('A.unitary()')
+    assert 'A' in v
+    assert np.allclose(v['A'].v, v['A'].unitary().v)
+
+
 def test_parse(rng):
     v = Vocabulary(64, rng=rng)
     v.populate('A; B; C')

--- a/nengo_spa/tests/test_vocabulary.py
+++ b/nengo_spa/tests/test_vocabulary.py
@@ -71,6 +71,14 @@ def test_populate_with_transform_on_first_vector(rng):
     assert np.allclose(v['A'].v, v['A'].unitary().v)
 
 
+def test_populate_with_transform_on_nonstrict_vocab(rng):
+    v = Vocabulary(64, rng=rng, strict=False)
+
+    v.populate('A.unitary()')
+    assert 'A' in v
+    assert np.allclose(v['A'].v, v['A'].unitary().v)
+
+
 def test_parse(rng):
     v = Vocabulary(64, rng=rng)
     v.populate('A; B; C')

--- a/nengo_spa/vocab.py
+++ b/nengo_spa/vocab.py
@@ -77,27 +77,28 @@ class Vocabulary(Mapping):
         candidate pointer with lowest maximum cosine with all existing
         pointers is returned.
         """
-        if len(self) == 0:
-            best_p = pointer.SemanticPointer(self.dimensions, rng=self.rng)
-        else:
-            best_p = None
-            best_sim = np.inf
-            for _ in range(attempts):
-                p = pointer.SemanticPointer(self.dimensions, rng=self.rng)
-                if transform is not None:
-                    p = eval('p.' + transform, {'p': p}, self)
+        best_p = None
+        best_sim = np.inf
+        for _ in range(attempts):
+            p = pointer.SemanticPointer(self.dimensions, rng=self.rng)
+            if transform is not None:
+                p = eval('p.' + transform, {'p': p}, self)
+            if len(self) == 0:
+                best_p = p
+                break
+            else:
                 p_sim = np.max(np.dot(self._vectors, p.v))
                 if p_sim < best_sim:
                     best_p = p
                     best_sim = p_sim
                     if p_sim < self.max_similarity:
                         break
-            else:
-                warnings.warn(
-                    'Could not create a semantic pointer with '
-                    'max_similarity=%1.2f (D=%d, M=%d)'
-                    % (self.max_similarity, self.dimensions,
-                       len(self.pointers)))
+        else:
+            warnings.warn(
+                'Could not create a semantic pointer with '
+                'max_similarity=%1.2f (D=%d, M=%d)'
+                % (self.max_similarity, self.dimensions,
+                   len(self.pointers)))
         return best_p
 
     def __contains__(self, key):

--- a/nengo_spa/vocab.py
+++ b/nengo_spa/vocab.py
@@ -82,7 +82,7 @@ class Vocabulary(Mapping):
         for _ in range(attempts):
             p = pointer.SemanticPointer(self.dimensions, rng=self.rng)
             if transform is not None:
-                p = eval('p.' + transform, {'p': p}, self)
+                p = eval('p.' + transform, dict(self), {'p': p})
             if len(self) == 0:
                 best_p = p
                 break
@@ -112,6 +112,14 @@ class Vocabulary(Mapping):
 
     def __getitem__(self, key):
         """Return the semantic pointer with the requested name."""
+        # __tracebackhide__ is used in py.test to hide stack frames from the
+        # traceback. That means py.test might try to look up this attribute
+        # in a test which will result in an exception hiding the actual
+        # exception. By raising a KeyError we indicate that there is no
+        # __tracebackhide__ attribute on this object and preserve the relevant
+        # exception.
+        if key == '__tracebackhide__':
+            raise KeyError()
         if not self.strict and key not in self:
             self.add(key, self.create_pointer())
         return self.pointers[key]


### PR DESCRIPTION
**Motivation and context:**
For the first vector that was added to a vocabulary the transform would not be applied. For examples `vocab.populate('A.unitary()')` would not produce a unitary vector if no other vectors have been added before.

**Interactions with other PRs:**
none

**How has this been tested?**
Added a regression test.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)
**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
