### PR TITLE
Add test for IdentityEnsembleArray network.

### DIFF
--- a/nengo_spa/networks/tests/test_identity_ensemble_array.py
+++ b/nengo_spa/networks/tests/test_identity_ensemble_array.py
@@ -1,0 +1,28 @@
+import nengo
+import numpy as np
+import pytest
+
+from nengo_spa.networks.identity_ensemble_array import IdentityEnsembleArray
+from nengo_spa.pointer import Identity, SemanticPointer
+
+
+@pytest.mark.parametrize('pointer', [Identity, SemanticPointer])
+def test_identity_ensemble_array(Simulator, seed, rng, pointer):
+    d = 64
+    try:
+        v = pointer(d, rng=rng).v
+    except TypeError:
+        v = pointer(d).v
+
+    with nengo.Network(seed=seed) as model:
+        ea = IdentityEnsembleArray(15, d, 4)
+        input_v = nengo.Node(v)
+        nengo.Connection(input_v, ea.input)
+        p = nengo.Probe(ea.output, synapse=0.01)
+
+    with Simulator(model) as sim:
+        sim.run(0.3)
+
+    actual = np.mean(sim.data[p][sim.trange() > 0.2], axis=0)
+    assert np.abs(v[0] - actual[0]) < 0.1
+    assert np.linalg.norm(v - actual) < 0.2


### PR DESCRIPTION
**Motivation and context:**
The `IdentityEnsembleArray` network was missing a test which is added in this PR.
Note that the dimensionality in that test chosen so that the test would fail for a `spa.State(d, represent_identity=False)`.

Closes #24.

Last PR before the 0.2 release. :)

**Interactions with other PRs:**
none

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.