### PR TITLE
Fix FFT operation for odd vector lengths.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,13 @@ Release History
 0.2.1 (unreleased)
 ==================
 
+**Fixed**
+
+- Fix some operations changing the dimensionality of semantic pointers with an
+  odd initial dimensionality.
+  (`#52 <https://github.com/nengo/nengo_spa/issues/52>`_,
+  `#53 <https://github.com/nengo/nengo_spa/pull/53>`_)
+
 
 0.2 (June 22, 2017)
 ===================

--- a/nengo_spa/pointer.py
+++ b/nengo_spa/pointer.py
@@ -40,7 +40,8 @@ class SemanticPointer(object):
         fft_real = fft_val.real
         fft_norms = np.sqrt(fft_imag ** 2 + fft_real ** 2)
         fft_unit = fft_val / fft_norms
-        return SemanticPointer(np.array((np.fft.ifft(fft_unit)).real))
+        return SemanticPointer(np.array((np.fft.ifft(
+            fft_unit, n=len(self))).real))
 
     def copy(self):
         """Return another semantic pointer with the same data."""
@@ -98,7 +99,9 @@ class SemanticPointer(object):
 
     def convolve(self, other):
         """Return the circular convolution of two SemanticPointers."""
-        x = np.fft.irfft(np.fft.rfft(self.v) * np.fft.rfft(other.v))
+        assert len(self) == len(other)
+        n = len(self)
+        x = np.fft.irfft(np.fft.rfft(self.v) * np.fft.rfft(other.v), n=n)
         return SemanticPointer(data=x)
 
     def get_convolution_matrix(self):

--- a/nengo_spa/tests/test_pointer.py
+++ b/nengo_spa/tests/test_pointer.py
@@ -54,8 +54,9 @@ def test_str():
     assert str(a) == '[ 1.  1.]'
 
 
-def test_make_unitary(rng):
-    a = SemanticPointer(100, rng=rng)
+@pytest.mark.parametrize('d', [65, 100])
+def test_make_unitary(d, rng):
+    a = SemanticPointer(d, rng=rng)
     b = a.unitary()
     assert a is not b
     assert np.allclose(1, b.length())
@@ -78,15 +79,16 @@ def test_add_sub():
     assert np.allclose((a + b).v, (a - (-b)).v)
 
 
-def test_convolution(rng):
-    a = SemanticPointer(64, rng=rng)
-    b = SemanticPointer(64, rng=rng)
-    identity = SemanticPointer(np.eye(64)[0])
+@pytest.mark.parametrize('d', [64, 65])
+def test_convolution(d, rng):
+    a = SemanticPointer(d, rng=rng)
+    b = SemanticPointer(d, rng=rng)
+    identity = SemanticPointer(np.eye(d)[0])
 
     c = a.copy()
     c *= b
 
-    ans = np.fft.irfft(np.fft.rfft(a.v) * np.fft.rfft(b.v))
+    ans = np.fft.irfft(np.fft.rfft(a.v) * np.fft.rfft(b.v), n=d)
 
     assert np.allclose((a * b).v, ans)
     assert np.allclose(a.convolve(b).v, ans)


### PR DESCRIPTION
**Motivation and context:**
Odd vector lengths would produce output vectors smaller by one element.
Fixes #52.

**Interactions with other PRs:**
none

**How has this been tested?**
added odd vector dimensionalities to relevant tests

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [ ] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.