### PR TITLE
Add output methods to IdentityEnsembleArray

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,14 @@ Release History
 0.2.1 (unreleased)
 ==================
 
+**Added**
+
+- Add ``add_output`` and ``add_neuron_output`` methods to
+  ``IdentityEnsembleArray`` to provide the full API that is provided by the
+  regular Nengo ``EnsembleArray``.
+  (`#61 <https://github.com/nengo/nengo_spa/pull/61>`_,
+  `#28 <https://github.com/nengo/nengo_spa/issues/28>`_)
+
 **Changed**
 
 - Actions will be build automatically without an explicit call to ``build()``.

--- a/nengo_spa/networks/tests/test_identity_ensemble_array.py
+++ b/nengo_spa/networks/tests/test_identity_ensemble_array.py
@@ -4,6 +4,7 @@ import pytest
 
 from nengo_spa.networks.identity_ensemble_array import IdentityEnsembleArray
 from nengo_spa.pointer import Identity, SemanticPointer
+from nengo_spa.testing import sp_close
 
 
 @pytest.mark.parametrize('pointer', [Identity, SemanticPointer])
@@ -26,3 +27,47 @@ def test_identity_ensemble_array(Simulator, seed, rng, pointer):
     actual = np.mean(sim.data[p][sim.trange() > 0.2], axis=0)
     assert np.abs(v[0] - actual[0]) < 0.1
     assert np.linalg.norm(v - actual) < 0.2
+
+
+def test_add_output(Simulator, seed, rng, plt):
+    d = 8
+    pointer = SemanticPointer(d, rng=rng)
+
+    with nengo.Network(seed=seed) as model:
+        ea = IdentityEnsembleArray(15, d, 4)
+        input_node = nengo.Node(pointer.v)
+        nengo.Connection(input_node, ea.input)
+        out = ea.add_output('const', lambda x: -x)
+        assert ea.const is out
+        p = nengo.Probe(out, synapse=0.01)
+
+    with Simulator(model) as sim:
+        sim.run(0.3)
+
+    plt.plot(sim.trange(), np.dot(sim.data[p], -pointer.v))
+    assert sp_close(sim.trange(), sim.data[p], -pointer, skip=0.2, atol=0.3)
+
+
+def test_add_output_multiple_fn(Simulator, seed, rng, plt):
+    d = 8
+    pointer = SemanticPointer(d, rng=rng)
+
+    with nengo.Network(seed=seed) as model:
+        ea = IdentityEnsembleArray(15, d, 4)
+        input_node = nengo.Node(pointer.v)
+        nengo.Connection(input_node, ea.input)
+        out = ea.add_output(
+            'const', (lambda x: -x, lambda x: .5 * x, lambda x: x))
+        assert ea.const is out
+        p = nengo.Probe(out, synapse=0.01)
+
+    with Simulator(model) as sim:
+        sim.run(0.3)
+
+    v = np.array(pointer.v)
+    v[0] *= -1.
+    v[1:4] *= .5
+    expected = SemanticPointer(v)
+
+    plt.plot(sim.trange(), np.dot(sim.data[p], expected.v))
+    assert sp_close(sim.trange(), sim.data[p], expected, skip=0.2, atol=0.3)


### PR DESCRIPTION
**Motivation and context:**
Adds `add_output` and `add_neuron_output` methods to `IdentityEnsembleArray` to provide the same API as `EnsembleArray`.

**Interactions with other PRs:**
none

**How has this been tested?**
added new tests

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.