### PR TITLE
Translate improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,10 @@ Release History
   when actually required.
   (`#60 <https://github.com/nengo/nengo_spa/pull/60>`_,
   `#42 <https://github.com/nengo/nengo_spa/issues/42>`_)
+- The vocabulary translate mechanism will properly ignore missing keys in the
+  target vocabulary when ``populate=False``.
+  (`#62 <https://github.com/nengo/nengo_spa/pull/62>`_,
+  `#56 <https://github.com/nengo/nengo_spa/issues/56>`_)
 
 
 0.2 (June 22, 2017)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,11 @@ Release History
   Nengo networks.
   (`#65 <https://github.com/nengo/nengo_spa/pull/65>`_,
   `#26 <https://github.com/nengo/nengo_spa/issues/26>`_)
+- Add a ``solver`` argument to the action rule's ``translate`` to use a solver
+  instead of an outer product to obtain the transformation matrix which can
+  give slightly better results.
+  (`#56 <https://github.com/nengo/nengo_spa/pull/56>`_,
+  `#57 <https://github.com/nengo/nengo_spa/issues/57>`_)
 
 **Changed**
 

--- a/nengo_spa/ast.py
+++ b/nengo_spa/ast.py
@@ -59,7 +59,8 @@ ApproxInverse: '~' Source
 Negative: '-' Source
 DotProduct: 'dot(' Source ',' Source ')'
 Reinterpret: 'reinterpret(' Source (',' VocabArg)? ')'
-Translate: 'translate(' Source (',' VocabArg)? ')'
+Translate: 'translate(' Source (',' TranslateArg)* ')'
+TranslateArg : <valid Python identifier> '=' <valid Python argument> | VocabArg
 VocabArg: 'vocab='? (Module | <valid Python identifier>)
 Sink: <valid Python identifier> | <valid Python identifier> '.' Sink
 Effect: Sink '=' Source
@@ -899,12 +900,13 @@ class Reinterpret(Source):
 
 
 class Translate(Source):
-    def __init__(self, source, vocab=None, populate=None):
+    def __init__(self, source, vocab=None, populate=None, solver=None):
         source = ensure_node(source)
         super(Translate, self).__init__(staticity=source.staticity)
         self.source = source
         self.vocab = vocab
         self.populate = populate
+        self.solver = solver
 
     def infer_types(self, root_network, context_type):
         if self.vocab is None:
@@ -926,7 +928,7 @@ class Translate(Source):
 
     def construct(self, context):
         tr = self.source.type.vocab.transform_to(
-            self.type.vocab, populate=self.populate)
+            self.type.vocab, populate=self.populate, solver=self.solver)
         artifacts = self.source.construct(context)
         return [a.add_transform(tr) for a in artifacts]
 

--- a/nengo_spa/tests/test_network.py
+++ b/nengo_spa/tests/test_network.py
@@ -151,7 +151,8 @@ def test_no_magic_vocab_transform():
     (16, 16, 'reinterpret(a, b)', 'v1'),
     (16, 32, 'translate(a, v2)', 'v2'),
     (16, 32, 'translate(a)', 'v2'),
-    (16, 32, 'translate(a, b)', 'v2')])
+    (16, 32, 'translate(a, b)', 'v2'),
+    (16, 32, 'translate(a, solver=nengo.solvers.Lstsq())', 'v2')])
 def test_casting_vocabs(d1, d2, method, lookup, Simulator, plt, rng):
     v1 = spa.Vocabulary(d1, rng=rng)
     v1.populate('A')

--- a/nengo_spa/vocab.py
+++ b/nengo_spa/vocab.py
@@ -237,7 +237,7 @@ class Vocabulary(Mapping):
                         "argument to silence this warning or "
                         "`populate=True` to automatically add missing "
                         "keys to the target vocabulary."))
-                elif populate:
+                if populate:
                     other.populate(k)
                 else:
                     continue

--- a/nengo_spa/vocab.py
+++ b/nengo_spa/vocab.py
@@ -206,7 +206,7 @@ class Vocabulary(Mapping):
             v = v.v
         return np.dot(self._vectors, v)
 
-    def transform_to(self, other, populate=None, keys=None):
+    def transform_to(self, other, populate=None, keys=None, solver=None):
         """Create a linear transform from one Vocabulary to another.
 
         This is simply the sum of the outer products of the corresponding
@@ -243,7 +243,10 @@ class Vocabulary(Mapping):
 
         from_vocab = self.create_subset(keys - missing_keys).vectors
         to_vocab = other.create_subset(keys - missing_keys).vectors
-        return np.dot(to_vocab.T, from_vocab)
+        if solver is None:
+            return np.dot(to_vocab.T, from_vocab)
+        else:
+            return solver(from_vocab, to_vocab)[0].T
 
     def create_subset(self, keys):
         """Returns the subset of this vocabulary.


### PR DESCRIPTION
**Motivation and context:**
This PR makes a couple of improvements to the vocabulary translation mechanism.

* Missing keys in the target vocabulary will be properly ignored when `populate=False`. This fixes #56.
* Adds a solver argument proposed by @arvoelke that can give slightly better transformation matrices.

To make it possible to use the solver argument in action rules, I imported the whole nengo name space into the action rule built-ins. But it occured to me that this cannot be the final solution because solvers might be defined outside of nengo and these solvers should be usable to. However, making all globals accessible is also problematic because names can refer to modules or semantic pointers and at parse time this can currently not be determined (technically it should be possible, but will require some major changes to the parsing). Maybe the best option is to have the user explicitely populate the builtin namespace, but this will increase boiler plate code.

**Interactions with other PRs:**
none

**How has this been tested?**
added tests

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Where should a reviewer start?**
Might make sense to do this one in order of the commits.

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Still to do:**
- [x] Figure out a better and more general way to provide access to solvers in action rules.