### PR TITLE
Allow empty string in Vocabulary.populate().

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,6 +70,8 @@ Release History
   target vocabulary when ``populate=False``.
   (`#62 <https://github.com/nengo/nengo_spa/pull/62>`_,
   `#56 <https://github.com/nengo/nengo_spa/issues/56>`_)
+- Allow empty string as argument to `Vocabulary.populate`.
+  (`#73 <https://github.com/nengo_spa/nengo/pull/73>`_)
 
 
 0.2 (June 22, 2017)

--- a/nengo_spa/tests/test_vocabulary.py
+++ b/nengo_spa/tests/test_vocabulary.py
@@ -22,6 +22,10 @@ def test_add(rng):
 def test_populate(rng):
     v = Vocabulary(64, rng=rng)
 
+    v.populate('')
+    v.populate(' \r\n\t')
+    assert len(v) == 0
+
     v.populate('A')
     assert 'A' in v
 

--- a/nengo_spa/vocab.py
+++ b/nengo_spa/vocab.py
@@ -150,6 +150,9 @@ class Vocabulary(Mapping):
         self._vectors = np.vstack([self._vectors, p.v])
 
     def populate(self, pointers):
+        if len(pointers.strip()) <= 0:
+            return  # Do nothing (and don't fail) for empty string.
+
         for p_expr in pointers.split(';'):
             assign_split = p_expr.split('=', 1)
             modifier_split = p_expr.split('.', 1)


### PR DESCRIPTION
**Motivation and context:**
This allows easier handling of situations where a `';'.join(keys)` results in an empty string. We decided at the last dev meeting to not raise an error in this case.

**Interactions with other PRs:**
none

**How has this been tested?**
Added ad test.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Where should a reviewer start?**
<!--- If the PR warrants it, indicate where a reviewer should start reviewing. -->
<!--- All lengthy PRs and complicated average PRs warrant this section. -->
<!--- If the PR is quick or straightforward, remove this section. -->

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.