### PR TITLE
Fix validation of vocab related params.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ notifications:
 
 env:
   global:
-    - NENGO="2.4"
+    - NENGO="2.5"
     - NUMPY="1.12"
     - SCIPY="true"
     - COVERAGE="false"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,8 +20,11 @@ Release History
    - Fixed
 
 
-0.3.2 (unreleased)
+0.4.0 (unreleased)
 ==================
+
+This release increases the minimum required Nengo version to Nengo 2.5
+(previously Nengo 2.4).
 
 **Added**
 
@@ -39,6 +42,9 @@ Release History
   do not have any effect.
   (`#101 <https://github.com/nengo/nengo_spa/issues/101>`_,
   `#103 <https://github.com/nengo/nengo_spa/pull/103>`_)
+- Validation of ``VocabOrDimParam`` and ``VocabularyMapParam``.
+  (`#95 <https://github.com/nengo/nengo_spa/issues/95>`_,
+  `#98 <https://github.com/nengo/nengo_spa/pull/98>`_)
 
 
 0.3.1 (November 7, 2017)

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Project status
 Installation
 ============
 
-Nengo SPA depends on `Nengo 2.4+ <https://nengo.github.io/>`_, and we recommend
+Nengo SPA depends on `Nengo 2.5+ <https://nengo.github.io/>`_, and we recommend
 that you install Nengo before installing Nengo SPA.
 
 To install Nengo SPA::

--- a/nengo_spa/tests/test_vocabulary.py
+++ b/nengo_spa/tests/test_vocabulary.py
@@ -9,6 +9,7 @@ import pytest
 from nengo_spa import Vocabulary, VocabularyMap
 from nengo_spa.exceptions import SpaParseError
 from nengo_spa.pointer import Identity
+from nengo_spa.vocab import VocabularyMapParam, VocabularyOrDimParam
 
 
 def test_add(rng):
@@ -251,3 +252,46 @@ def test_vocabulary_set(rng):
     assert vs[16] is new
     assert new.dimensions == 16
     assert new.rng is rng
+
+
+def test_vocabulary_map_param():
+    class Test(object):
+        vocab_map = VocabularyMapParam('vocab_map', readonly=False)
+
+    obj = Test()
+    vm = VocabularyMap()
+    v16 = Vocabulary(16)
+    v32 = Vocabulary(32)
+
+    obj.vocab_map = vm
+    assert obj.vocab_map is vm
+
+    obj.vocab_map = [v16, v32]
+    assert obj.vocab_map[16] is v16
+    assert obj.vocab_map[32] is v32
+
+    with pytest.raises(ValidationError):
+        obj.vocab_map = 'incompatible'
+
+
+def test_vocabulary_or_dim_param():
+    v16 = Vocabulary(16)
+    v32 = Vocabulary(32)
+
+    class Test(object):
+        vocabs = VocabularyMap([v16])
+        vocab = VocabularyOrDimParam('vocab', readonly=False)
+
+    obj = Test()
+
+    obj.vocab = v32
+    assert obj.vocab is v32
+
+    obj.vocab = 16
+    assert obj.vocab is v16
+
+    with pytest.raises(ValidationError):
+        obj.vocab = 'incompatible'
+
+    with pytest.raises(ValidationError):
+        obj.vocab = 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-nengo>=2.4
+nengo>=2.5
 numpy>=1.7

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'numpy>=1.7',
     ],
     install_requires=[
-        'nengo>=2.4',
+        'nengo>=2.5',
         'numpy>=1.7',
     ],
     extras_require={


### PR DESCRIPTION
**Motivation and context:**
Fixes the validation of vocabulary related parameters. This was necessary as the `validate` and `__set__` methods on parameters were replaced by a `coerce` method in Nengo 2.5. This also bumps the minimum Nengo version for nengo_spa to 2.5.

Fixes #95.

**Interactions with other PRs:**
none

**How has this been tested?**
added tests

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.