### PR TITLE
Allow noop actions with pass keyword.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,10 @@ Release History
 - Allow the ``spa.Actions`` string to be empty.
   (`#107 <https://github.com/nengo/nengo_spa/issues/107>`_,
   `#109 <https://github.com/nengo/nengo_spa/pull/109>`_)
+- The ``pass`` keyword can now be used to create blocks in action rules that
+  do not have any effect.
+  (`#101 <https://github.com/nengo/nengo_spa/issues/101>`_,
+  `#103 <https://github.com/nengo/nengo_spa/pull/103>`_)
 
 
 0.3.1 (November 7, 2017)

--- a/nengo_spa/compiler/ast_nodes.py
+++ b/nengo_spa/compiler/ast_nodes.py
@@ -825,7 +825,8 @@ class Effects(Node):
     """Multiple effects."""
     def __init__(self, effects, name=None):
         super(Effects, self).__init__(
-            staticity=max(e.staticity for e in effects))
+            staticity=max(e.staticity for e in effects)
+            if len(effects) > 0 else self.Staticity.FIXED)
         self.type = TEffects
         self.effects = effects
         self.name = name

--- a/nengo_spa/tests/test_actions.py
+++ b/nengo_spa/tests/test_actions.py
@@ -242,3 +242,13 @@ def test_provides_access_to_constructed_objects_of_effect():
             else:
                 raise AssertionError("Unexpected object constructed for Bind.")
         assert n_connections == 2 and n_bind == 1
+
+
+def test_noop_action():
+    with spa.Network():
+        actions = spa.Actions('''
+            ifmax 0.5:
+                pass
+        ''')
+
+    assert actions[0].bg.input.size_in == 1


### PR DESCRIPTION
**Motivation and context:**
Allows actions without any effect by using Python's `pass` keyword:
```python
spa.Actions('''
    ifmax 0.5:
        pass
''')
```

Fixes #101.

**Interactions with other PRs:**
none

**How has this been tested?**
added a test

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [x] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

**Still to do:**
<!--- If this is a work in progress, note below what you stil plan to do. -->
<!--- Use the task list syntax `- [ ]` so that progress can be tracked. -->
