### PR TITLE
Fix warnings related things

### DIFF
--- a/nengo_spa/tests/test_vocabulary.py
+++ b/nengo_spa/tests/test_vocabulary.py
@@ -2,7 +2,6 @@
 
 from nengo.exceptions import NengoWarning, ValidationError
 import nengo.solvers
-from nengo.utils.testing import warns
 import numpy as np
 import pytest
 
@@ -167,7 +166,7 @@ def test_transform(recwarn, rng, solver):
     # Test warns on missing keys
     v1.populate('D')
     D = v1['D']
-    with warns(NengoWarning):
+    with pytest.warns(NengoWarning):
         v1.transform_to(v2, solver=solver)
 
     # Test populating missing keys
@@ -184,7 +183,7 @@ def test_create_pointer_warning(rng):
     v = Vocabulary(2, rng=rng)
 
     # five pointers shouldn't fit
-    with warns(UserWarning):
+    with pytest.warns(UserWarning):
         v.populate('A; B; C; D; E')
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ markers =
     slow: Mark a test as slow to skip it per default.
 filterwarnings =
     ignore:Could not create a semantic pointer
+    ignore::ImportWarning
 
 [tox]
 envlist = py27,py34,py35,py36,static


### PR DESCRIPTION
**Motivation and context:**
Do not depend on `nengo.utils.testing.warns` which has been removed in the Nengo development version and filter irrelevant warnings.

Closes #123.

**Interactions with other PRs:**
none

**How has this been tested?**
ran the tests

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Non-code change (touches things like tests, documentation, build scripts)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
