### PR TITLE
Naming of ifmax actions

### DIFF
--- a/nengo_spa/actions.py
+++ b/nengo_spa/actions.py
@@ -133,13 +133,16 @@ class ActionSelection(object):
     def __exit__(self, exc_type, exc_value, traceback):
         ActionSelection.active = None
 
-        if exc_type is not None:
-            return
+        try:
+            if exc_type is not None:
+                return
 
-        if len(RoutedConnection._free_floating) > 0:
-            raise SpaActionSelectionError(
-                "All actions in an action selection context must be part of "
-                "an ifmax call.")
+            if len(RoutedConnection._free_floating) > 0:
+                raise SpaActionSelectionError(
+                    "All actions in an action selection context must be part "
+                    "of an ifmax call.")
+        finally:
+            RoutedConnection._free_floating.clear()
 
         if len(self._utilities) <= 0:
             return

--- a/nengo_spa/actions.py
+++ b/nengo_spa/actions.py
@@ -120,6 +120,7 @@ class ActionSelection(object):
         self.thalamus = None
         self._utilities = []
         self._actions = []
+        self._names = []
 
     def __enter__(self):
         assert not self.built
@@ -169,20 +170,26 @@ class ActionSelection(object):
 
         self.built = True
 
-    def add_action(self, *actions):
+    def keys(self):
+        return tuple(self._names)
+
+    def add_action(self, name, *actions):
         assert ActionSelection.active is self
         utility = nengo.Node(size_in=1)
         self._utilities.append(utility)
         self._actions.append(actions)
+        self._names.append(name)
         RoutedConnection._free_floating.difference_update(actions)
         return utility
 
 
-def ifmax(condition, *actions):
+def ifmax(name, condition, *actions):
     """Defines a potential action within an `ActionSelection` context.
 
     Parameters
     ----------
+    name : str
+        Name for the action
     condition : nengo_spa.ast.base.Node
         The utility value for the given actions.
     actions : sequence of `RoutedConnection`
@@ -206,6 +213,6 @@ def ifmax(condition, *actions):
         raise SpaActionSelectionError(
             "ifmax actions must be routing expressions like 'a >> b'.")
 
-    utility = ActionSelection.active.add_action(*actions)
+    utility = ActionSelection.active.add_action(name, *actions)
     condition.connect_to(utility)
     return utility

--- a/nengo_spa/modules/tests/test_thalamus.py
+++ b/nengo_spa/modules/tests/test_thalamus.py
@@ -124,14 +124,14 @@ def test_routing(Simulator, seed, plt):
     valueC = np.mean(data[550:600], axis=0)  # should be [1, 0, 0]
 
     assert valueA[0] < 0.2
-    assert valueA[1] > 0.75
+    assert valueA[1] > 0.7
     assert valueA[2] < 0.2
 
     assert valueB[0] < 0.2
     assert valueB[1] < 0.2
-    assert valueB[2] > 0.75
+    assert valueB[2] > 0.7
 
-    assert valueC[0] > 0.75
+    assert valueC[0] > 0.7
     assert valueC[1] < 0.2
     assert valueC[2] < 0.2
 

--- a/nengo_spa/network.py
+++ b/nengo_spa/network.py
@@ -2,7 +2,7 @@ import inspect
 
 import nengo
 from nengo.config import Config, SupportDefaultsMixin
-from nengo.utils.compat import is_number
+from nengo.utils.compat import is_number, is_string
 import numpy as np
 
 from nengo_spa.actions import ifmax as actions_ifmax
@@ -127,7 +127,7 @@ class SpaOperatorMixin(object):
         return as_ast_node(self).translate(vocab, populate, keys, solver)
 
 
-def ifmax(condition, *actions):
+def ifmax(name, condition, *actions):
     """Defines a potential action within an `ActionSelection` context.
 
     This implementation allows Nengo objects in addition to AST nodes as
@@ -135,6 +135,8 @@ def ifmax(condition, *actions):
 
     Parameters
     ----------
+    name : str, optional
+        Name for the action. Can be omitted.
     condition : nengo_spa.ast.base.Node or NengoObject
         The utility value for the given actions.
     actions : sequence of `RoutedConnection`
@@ -146,7 +148,12 @@ def ifmax(condition, *actions):
         Nengo object that can be connected to, to provide additional input to
         the utility value.
     """
-    return actions_ifmax(as_ast_node(condition), *actions)
+    if not is_string(name):
+        actions = (condition,) + actions
+        condition = name
+        name = None
+
+    return actions_ifmax(name, as_ast_node(condition), *actions)
 
 
 class Network(nengo.Network, SupportDefaultsMixin, SpaOperatorMixin):

--- a/nengo_spa/tests/test_actions.py
+++ b/nengo_spa/tests/test_actions.py
@@ -312,3 +312,15 @@ def test_action_selection_enforces_connections_to_be_part_of_action():
         with pytest.raises(SpaActionSelectionError):
             with ActionSelection():
                     state1 >> state2
+
+
+def test_naming_of_actions():
+    with spa.Network():
+        state1 = spa.State(16)
+        state2 = spa.State(16)
+        with ActionSelection() as action_sel:
+            spa.ifmax('name1', 0., state1 >> state2)
+            spa.ifmax(0., state1 >> state2)
+            spa.ifmax('name2', 0., state1 >> state2)
+
+    assert action_sel.keys() == ('name1', None, 'name2')

--- a/nengo_spa/tests/test_actions.py
+++ b/nengo_spa/tests/test_actions.py
@@ -319,8 +319,12 @@ def test_naming_of_actions():
         state1 = spa.State(16)
         state2 = spa.State(16)
         with ActionSelection() as action_sel:
-            spa.ifmax('name1', 0., state1 >> state2)
-            spa.ifmax(0., state1 >> state2)
-            spa.ifmax('name2', 0., state1 >> state2)
+            u0 = spa.ifmax('name0', 0., state1 >> state2)
+            u1 = spa.ifmax(0., state1 >> state2)
+            u2 = spa.ifmax('name2', 0., state1 >> state2)
 
-    assert action_sel.keys() == ('name1', None, 'name2')
+    assert tuple(action_sel.keys()) == ('name0', 1, 'name2')
+    assert action_sel['name0'] is u0
+    assert action_sel['name2'] is u2
+    for i, u in enumerate((u0, u1, u2)):
+        assert action_sel[i] is u


### PR DESCRIPTION
**Motivation and context:**
Allows the naming of ifmax actions by providing an optional string as first argument to `ifmax`.

Furthermore, `ActionSelection` implements the dictionary interface. This allows to get the names with the `keys()` method (in some context the result might need an explicit cast to `list(action_sel.keys())`). Actions without a name will be assigned an integer index in this sequence. `ActionSelection` can either be indexed with the string names or integer indices to retrieve the corresponding utility input nodes.

Closes #132.

**Interactions with other PRs:**
#68 should be rebased once this PR has been merged.

**How has this been tested?**
Added a test.

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Average (neither quick nor lengthy)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- New feature (non-breaking change which adds functionality)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

