### PR TITLE
Remove unnecessary argument in Transcode functions.

### DIFF
--- a/nengo_spa/modules/tests/test_transcode.py
+++ b/nengo_spa/modules/tests/test_transcode.py
@@ -88,8 +88,8 @@ def test_encode_with_input(Simulator, seed):
 
 
 def test_transcode(Simulator, seed):
-    def transcode_fn(t, sp, vocab):
-        assert t < 0.15 or vocab.parse('A').dot(sp) > 0.8
+    def transcode_fn(t, sp):
+        assert t < 0.15 or sp.vocab.parse('A').dot(sp) > 0.8
         return 'B'
 
     with spa.Network(seed=seed) as model:
@@ -123,10 +123,10 @@ def test_decode(Simulator, seed):
         def __init__(self):
             self.called = False
 
-        def __call__(self, t, v, vocab):
+        def __call__(self, t, v):
             if t > 0.001:
                 self.called = True
-                assert_almost_equal(vocab.parse('A').v, v.v)
+                assert_almost_equal(v.vocab.parse('A').v, v.v)
 
     output_fn = OutputFn()
 
@@ -142,7 +142,7 @@ def test_decode(Simulator, seed):
 
 
 def test_decode_with_output(Simulator, seed):
-    def decode_fn(t, v, vocab):
+    def decode_fn(t, v):
         return [t]
 
     with spa.Network(seed=seed) as model:
@@ -156,7 +156,7 @@ def test_decode_with_output(Simulator, seed):
 
 
 def test_decode_size_out(Simulator, seed):
-    def decode_fn(t, v, vocab):
+    def decode_fn(t, v):
         return [t]
 
     with spa.Network(seed=seed) as model:

--- a/nengo_spa/modules/transcode.py
+++ b/nengo_spa/modules/transcode.py
@@ -25,7 +25,7 @@ class SpArrayExtractor(object):
 
 def make_sp_func(fn, vocab):
     def sp_func(t, v):
-        return fn(t, SemanticPointer(v), vocab)
+        return fn(t, SemanticPointer(v, vocab=vocab))
     return sp_func
 
 
@@ -57,8 +57,8 @@ class TranscodeFunctionParam(Parameter):
     def coerce_callable(self, obj, fn):
         t = 0.
         if obj.input_vocab is not None:
-            args = (t, SemanticPointer(obj.input_vocab.dimensions),
-                    obj.input_vocab)
+            args = (t, SemanticPointer(
+                obj.input_vocab.dimensions, vocab=obj.input_vocab))
         elif obj.size_in is not None:
             args = (t, np.zeros(obj.size_in))
         else:


### PR DESCRIPTION
**Motivation and context:**
With the new syntax, `SemanticPointer` can track their vocabulary. This makes the `vocab` argument in `Transcode` functions unneccessary as it can be retrieved from the Semantic Pointer that is passed in.

**Interactions with other PRs:**
Cherry-picked the commit from my local `docs` branch as it touches actual code and should be reviewed separately. Thus the same commit might at some point appear in PR #68.

**How has this been tested?**
existing tests

**How long should this take to review?**
<!--- Please estimate if this PR is a quick, average, or lengthy PR. -->
<!--- Take into account both the size and complexity of the changes. -->
<!--- Also note if this is a timely PR that should be reviewed by a certain date. -->
<!--- Leave only the line that applies below: -->

- Quick (less than 40 lines changed or changes are straightforward)

**Types of changes:**
<!--- What types of changes does your code introduce? -->
<!--- Leave all lines that apply below: -->

- Breaking change (fix or feature that causes existing functionality to change)

**Checklist:**
<!--- Go over all the following points. Put an `x` in all the boxes that apply. -->
<!--- If a box is not applicable, please justify below the checklist. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
<!--- We're here to help! -->

- [x] I have read the **CONTRIBUTING.rst** document.
- [n/a] I have updated the documentation accordingly.
- [n/a] I have included a changelog entry.
- [n/a] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.

